### PR TITLE
Add rawappend, catch Throwable, ignore temp files

### DIFF
--- a/src/main/java/net/vhati/modmanager/cli/SlipstreamCLI.java
+++ b/src/main/java/net/vhati/modmanager/cli/SlipstreamCLI.java
@@ -456,7 +456,7 @@ public class SlipstreamCLI {
 		}
 
 		@Override
-		public synchronized void patchingEnded( boolean outcome, Exception e ) {
+		public synchronized void patchingEnded( boolean outcome, Throwable e ) {
 			succeeded = outcome;
 			done = true;
 		}

--- a/src/main/java/net/vhati/modmanager/core/ModPatchObserver.java
+++ b/src/main/java/net/vhati/modmanager/core/ModPatchObserver.java
@@ -31,5 +31,5 @@ public interface ModPatchObserver {
 	 * Patching ended.
 	 * If anything went wrong, e may be non-null.
 	 */
-	public void patchingEnded( boolean outcome, Exception e );
+	public void patchingEnded( boolean outcome, Throwable e );
 }

--- a/src/main/java/net/vhati/modmanager/ui/DatExtractDialog.java
+++ b/src/main/java/net/vhati/modmanager/ui/DatExtractDialog.java
@@ -49,7 +49,7 @@ public class DatExtractDialog extends ProgressDialog {
 	}
 
 	@Override
-	protected void setTaskOutcome( boolean outcome, Exception e ) {
+	protected void setTaskOutcome( boolean outcome, Throwable e ) {
 		super.setTaskOutcome( outcome, e );
 		if ( !this.isShowing() ) return;
 

--- a/src/main/java/net/vhati/modmanager/ui/ModPatchDialog.java
+++ b/src/main/java/net/vhati/modmanager/ui/ModPatchDialog.java
@@ -58,13 +58,13 @@ public class ModPatchDialog extends ProgressDialog implements ModPatchObserver {
 	 * If anything went wrong, e may be non-null.
 	 */
 	@Override
-	public void patchingEnded( boolean outcome, Exception e ) {
+	public void patchingEnded( boolean outcome, Throwable e ) {
 		setTaskOutcomeLater( outcome, e );
 	}
 
 
 	@Override
-	protected void setTaskOutcome( boolean outcome, Exception e ) {
+	protected void setTaskOutcome( boolean outcome, Throwable e ) {
 		super.setTaskOutcome( outcome, e );
 		if ( !this.isShowing() ) return;
 

--- a/src/main/java/net/vhati/modmanager/ui/ProgressDialog.java
+++ b/src/main/java/net/vhati/modmanager/ui/ProgressDialog.java
@@ -172,7 +172,7 @@ public class ProgressDialog extends JDialog implements ActionListener {
 	 *
 	 * If anything went wrong, e may be non-null.
 	 */
-	public void setTaskOutcomeLater( final boolean success, final Exception e ) {
+	public void setTaskOutcomeLater( final boolean success, final Throwable e ) {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
@@ -181,7 +181,7 @@ public class ProgressDialog extends JDialog implements ActionListener {
 		});
 	}
 
-	protected void setTaskOutcome( final boolean outcome, final Exception e ) {
+	protected void setTaskOutcome( final boolean outcome, final Throwable e ) {
 		done = true;
 		succeeded = outcome;
 


### PR DESCRIPTION
- Added .rawappend extension which instructs the manager to append the
  file using pre-1.2 method
- Catching a Throwable instead of an Exception allows the manager to
  gracefully recover from an OutOfMemoryError... But too general a catch
  case = bad?
- Told the manager to ignore files starting or ending with a ~ tilde,
  assuming that they're temporary files (probably a botched idea, since there's no guarantee they're _actually_ temp files)

Sorry for putting everything in one commit, Github has gone crazy with my previous fork and insisted that there were changes where there were none, had to re-fork the repo to fix that...
