### PR TITLE
Improve wording when stating date of unknown mod

### DIFF
--- a/src/main/java/net/vhati/modmanager/ui/ManagerFrame.java
+++ b/src/main/java/net/vhati/modmanager/ui/ManagerFrame.java
@@ -619,9 +619,9 @@ public class ManagerFrame extends JFrame implements ActionListener, ModsScanObse
 				body += "No info is available for the selected mod.\n\n";
 
 				if ( modDate != null ) {
-					SimpleDateFormat dateFormat = new SimpleDateFormat( "yyyy/MM/dd" );
+					SimpleDateFormat dateFormat = new SimpleDateFormat( "yyyy-MM-dd" );
 					String dateString = dateFormat.format( modDate );
-					body += "It was released sometime after "+ dateString +".\n\n";
+					body += "It was released some time after "+ dateString +".\n\n";
 				} else {
 					body += "The date of its release could not be determined.\n\n";
 				}


### PR DESCRIPTION
- Change the date format to use hyphens `-` as separators instead of slashes `/`, so that the format matches the widely-known [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) standard for date formatting.
- Change “sometime” to “some time” – “sometime” is a word, but it has a different set of meanings from “some time”, and does not apply here.
