### PR TITLE
Repairs a small Ubuntu issue regarding enviroment variables and auto-detection

### DIFF
--- a/src/main/java/net/vhati/modmanager/core/FTLUtilities.java
+++ b/src/main/java/net/vhati/modmanager/core/FTLUtilities.java
@@ -33,9 +33,13 @@ public class FTLUtilities {
 		String humblePath = "FTL/resources";
 
 		String xdgDataHome = System.getenv("XDG_DATA_HOME");
-		if ( xdgDataHome == null )
+		if ( xdgDataHome == null ) {
 			xdgDataHome = System.getProperty("user.home") +"/.local/share";
-
+		}
+		String xdgDataHomeUbuntu = System.getenv("HOME");
+		if (xdgDataHomeUbuntu == null) {
+			xdgDataHome = System.getProperty("user.home") +"/.local/share";
+		}
 		File[] candidates = new File[] {
 			// Windows - Steam
 			new File( new File(""+System.getenv("ProgramFiles(x86)")), steamPath ),
@@ -49,6 +53,11 @@ public class FTLUtilities {
 			// Linux - Steam
 			new File( xdgDataHome +"/Steam/SteamApps/common/FTL Faster Than Light/data/resources" ),
 			new File( xdgDataHome +"/.steam/steam/SteamApps/common/FTL Faster Than Light/data/resources" ),
+			new File( xdgDataHome +"/.steam/steamapps/common/FTL Faster Than Light/data/resources" ),
+			// Ubuntu - Steam xdgfix
+			new File( xdgDataHomeUbuntu +"/Steam/SteamApps/common/FTL Faster Than Light/data/resources" ),
+			new File( xdgDataHomeUbuntu +"/.steam/steam/SteamApps/common/FTL Faster Than Light/data/resources" ),
+			new File( xdgDataHomeUbuntu +"/.steam/steam/steamapps/common/FTL Faster Than Light/data/resources" ),
 			// OSX - Steam
 			new File( System.getProperty("user.home") +"/Library/Application Support/Steam/SteamApps/common/FTL Faster Than Light/FTL.app/Contents/Resources" ),
 			// OSX


### PR DESCRIPTION
Ubuntu has an issue regarding XDG variables causing it fail finding data.dat. This causes steam to set the default folder to $HOME rather than $XDG_HOME_DATA. This in turn causes Slipstream to fail seeing the data folder of FTL, prompting a user to do it manually. 

This fix first looks for the default enviroment, then looks for the folder using HOME and then resorts to the manual option.

https://bugs.launchpad.net/ubuntu/+source/xdg-user-dirs/+bug/1122613 - The issue on launchpad.

I got the code thanks to Niels-NTG through this issue at his project: Niels-NTG/FTLAV#1