### PR TITLE
fix a missing comma in auto_update.json

### DIFF
--- a/skel_common/backup/auto_update.json
+++ b/skel_common/backup/auto_update.json
@@ -15,7 +15,7 @@
 					"version" : "1.7",
 					"hidden" : "true",
 					"changes" : [
-						"Added a config option to launch FTL via Steam, if possible"
+						"Added a config option to launch FTL via Steam, if possible",
 						"Added an alternate location to automatically find SteamApps/ on linux"
 					]
 				},


### PR DESCRIPTION
This was spitting out a json parsing error whenever I launch SMM on windows 7.  Pretty simple syntax error, but it might be breaking... something.  I was having a problem where anytime I'd patch the game (even with no mods) it would corrupt the game so that it crashes immediately after loading.  After I fixed this file in my install, it seemed to work.