### PR TITLE
Fixed setDisposeNormally() ignoring the argument

### DIFF
--- a/src/main/java/net/vhati/modmanager/ui/ManagerFrame.java
+++ b/src/main/java/net/vhati/modmanager/ui/ManagerFrame.java
@@ -1065,7 +1065,7 @@ public class ManagerFrame extends JFrame implements ActionListener, ModsScanObse
 	 * Set this to false before an abnormal exit.
 	 */
 	public void setDisposeNormally( boolean b ) {
-		disposeNormally = false;
+		disposeNormally = b;
 	}
 
 	@Override


### PR DESCRIPTION
Calling `ManagerFrame.setDisposeNormally()` would always set the `disposeNormally` variable to false, regardless of the argument value.