### PR TITLE
replaced bash shebang with more portable one

### DIFF
--- a/skel_unix/modman-cli.sh
+++ b/skel_unix/modman-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the absolute path to this script's folder.
 if echo "$0" | awk '{exit(!/^\//);}'; then

--- a/skel_unix/modman.command
+++ b/skel_unix/modman.command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the script's name.
 me=$(basename "$0");


### PR DESCRIPTION
Hello,

When trying to use slipstream on my own computer I noticed that the shell scripts use `#!/bin/bash` as their default execution shebang. This works fine on any system that happens to have bash installed but not all systems have that particular bourne compatible shell installed on them by default or that have it installed but not at that particular path.

A much more portable way to reference bash is though this shebang: `#!/usr/bin/env bash`

More reading can be found in this stack overflow thread if you want: https://unix.stackexchange.com/questions/632053/how-to-get-bin-bash-on-nixos